### PR TITLE
IfcParser UTF-32 bugfix

### DIFF
--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcParserWriterUtils.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcParserWriterUtils.java
@@ -143,7 +143,7 @@ public class IfcParserWriterUtils {
 			if (indexOfEnd == -1) {
 				throw new DeserializeException(lineNumber, "\\X4\\ not closed with \\X0\\");
 			}
-			if ((indexOfEnd - index) % 8 != 0) {
+			if ((indexOfEnd - (index + 4)) % 8 != 0) {
 				throw new DeserializeException(lineNumber, "Number of hex chars in \\X4\\ definition not divisible by 8");
 			}
 			try {

--- a/IfcPlugins/test/org/bimserver/test/TestStringDecode.java
+++ b/IfcPlugins/test/org/bimserver/test/TestStringDecode.java
@@ -11,6 +11,10 @@ public class TestStringDecode {
 	public void testOrder() {
 		try {
 			Assert.assertEquals("【S】铝合金-浅灰色（窗框）", IfcParserWriterUtils.readString("'\\X2\\3010\\X0\\S\\X2\\301194DD540891D1\\X0\\-\\X2\\6D4570708272FF087A976846FF09\\X0\\'", 0));
+                        // Nordic character in UTF-16:
+                        Assert.assertEquals("Vaffelrøre", IfcParserWriterUtils.readString("'Vaffelr\\X2\\00F8\\X0\\re'", 0));
+                        // Nordic character in UTF-32:
+                        Assert.assertEquals("Vaffelrøre", IfcParserWriterUtils.readString("'Vaffelr\\X4\\000000F8\\X0\\re'", 0));
 		} catch (DeserializeException e) {
 			Assert.fail(e.getMessage());
 		}


### PR DESCRIPTION
Stumbled upon UTF-32 chars in IFC not working, i.e. characters encoded like "\X4\00000000\X0\". IfcOpenShell seems to default to using this encoding.

Does this fix make sense?