### PR TITLE
Fix encoding issue, which crashed an import from BIMCollab

### DIFF
--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepStreamingDeserializer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepStreamingDeserializer.java
@@ -27,7 +27,6 @@ import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -78,6 +77,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 
+import it.unimi.dsi.fastutil.ints.Int2LongArrayMap;
 import nl.tue.buildingsmart.schema.Attribute;
 import nl.tue.buildingsmart.schema.EntityDefinition;
 import nl.tue.buildingsmart.schema.ExplicitAttribute;
@@ -140,7 +140,7 @@ public abstract class IfcStepStreamingDeserializer implements StreamingDeseriali
 	@Override
 	public long read(InputStream in, String filename, long fileSize, QueryContext reusable) throws DeserializeException {
 		this.reusable = reusable;
-		mappedObjects = new HashMap<>();
+		mappedObjects = new Int2LongArrayMap();
 		waitingList = new WaitingListVirtualObject();
 		mode = Mode.HEADER;
 		if (filename != null && (filename.toUpperCase().endsWith(".ZIP") || filename.toUpperCase().endsWith(".IFCZIP"))) {

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepStreamingDeserializer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepStreamingDeserializer.java
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 
-import it.unimi.dsi.fastutil.ints.Int2LongArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import nl.tue.buildingsmart.schema.Attribute;
 import nl.tue.buildingsmart.schema.EntityDefinition;
 import nl.tue.buildingsmart.schema.ExplicitAttribute;
@@ -140,7 +140,7 @@ public abstract class IfcStepStreamingDeserializer implements StreamingDeseriali
 	@Override
 	public long read(InputStream in, String filename, long fileSize, QueryContext reusable) throws DeserializeException {
 		this.reusable = reusable;
-		mappedObjects = new Int2LongArrayMap();
+		mappedObjects = new Int2LongOpenHashMap();
 		waitingList = new WaitingListVirtualObject();
 		mode = Mode.HEADER;
 		if (filename != null && (filename.toUpperCase().endsWith(".ZIP") || filename.toUpperCase().endsWith(".IFCZIP"))) {

--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/XPass.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/XPass.java
@@ -29,6 +29,7 @@ public class XPass extends Pass {
 	@Override
 	public String process(int lineNumber, String result) throws DeserializeException {
 		while (result.contains("\\X\\")) {
+			result = result.replace("\\\\",  "\\");
 			int index = result.indexOf("\\X\\");
 			int code = Integer.parseInt(result.substring(index + 3, index + 5), 16);
 			ByteBuffer b = ByteBuffer.wrap(new byte[] { (byte) (code) });


### PR DESCRIPTION
When checking in a file from BIMCollab example (here: https://www.bimcollab.com/en/Support/Support/Downloads/Examples-templates) we get this error:
`[03_BIMcollab_Example_MEP.ifczip] Error on line 32: (For input string: "\B") #26=IFCPROPERTYSINGLEVALUE('Temperature',$,IFCTEXT('0.00 \\X\\B0C'),$);`
 
That seems to be because of double anti-slash in the IFC file, although BIMServer expects single one.

So I propose just to transform double "\\" into single one, and file can be checked in successfully.
