### PR TITLE
Fix parsing nested lists in IfcStepDeserializer

### DIFF
--- a/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepDeserializer.java
+++ b/IfcPlugins/src/org/bimserver/ifc/step/deserializer/IfcStepDeserializer.java
@@ -449,6 +449,8 @@ public abstract class IfcStepDeserializer extends EmfDeserializer {
 					Class<?> instanceClass = newObject.eClass().getEStructuralFeature(WRAPPED_VALUE).getEType().getInstanceClass();
 					if (value.equals("")) {
 
+					} else if (value.charAt(0) == '(') {
+						readList(value, newObject, newObject.eClass().getEStructuralFeature(WRAPPED_VALUE));
 					} else {
 						if (instanceClass == Integer.class || instanceClass == int.class) {
 							try {


### PR DESCRIPTION
Hello,
We have found an issue in `IfcStepDeserializer` class. Parsing nested lists doesn't work. Example record from IFC4 file:

```
#53700= IFCINDEXEDPOLYCURVE(#53696,(IFCLINEINDEX((1,2))),$);
```

It throws:

```
org.bimserver.plugins.deserializers.DeserializeException: Error on line 108: (1,2) is not a valid integer(64) value
```

The reason is that parsing lists is not handled in `convert()` method.

The fix was tested with most of the files available in https://github.com/opensourceBIM/TestFiles/tree/master/TestData, but also with our private models and works properly for IFC2x3 and IFC4 files.

If the fix is approved, please let me know about a planned release date.
It is a very urgent issue for us.